### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -13,7 +13,7 @@ class ControllerTest extends PHPUnit_Framework_TestCase
     {
         $obj_controller = new Example();
         $obj_controller->dispatch();
-        $this->assertEquals($obj_controller->getResponse(), ['test' => TRUE]);
+        $this->assertEquals($obj_controller->getResponse(), ['test' => true]);
     }
 
     public function testQuery()
@@ -57,10 +57,10 @@ class ControllerTest extends PHPUnit_Framework_TestCase
 
     public function testCliHeaders()
     {
-        $_SERVER['HTTP_SOME_HEADER'] = TRUE;
+        $_SERVER['HTTP_SOME_HEADER'] = true;
         $obj_controller = new Headers();
         $obj_controller->dispatch();
-        $this->assertEquals($obj_controller->getResponse(), ['Some-Header' => TRUE]);
+        $this->assertEquals($obj_controller->getResponse(), ['Some-Header' => true]);
     }
 
     public function testJsonBodyParam()

--- a/tests/Controllers/Example.php
+++ b/tests/Controllers/Example.php
@@ -3,6 +3,6 @@
 class Example extends \Docnet\JAPI\Controller
 {
     public function dispatch(){
-        $this->setResponse(['test' => TRUE]);
+        $this->setResponse(['test' => true]);
     }
 }

--- a/tests/JAPITest.php
+++ b/tests/JAPITest.php
@@ -96,7 +96,7 @@ class JAPITest extends PHPUnit_Framework_TestCase
         // Mock JAPI
         $obj_japi = $this->getMockBuilder('\\Docnet\\JAPI')->setMethods(['sendResponse'])->getMock();
         $obj_japi->expects($this->once())->method('sendResponse')->with(
-            $this->equalTo(['test' => TRUE]),
+            $this->equalTo(['test' => true]),
             $this->equalTo(200)
         );
 


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!